### PR TITLE
Move mark-unread to browser.storage.local (#631)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"to-markdown": "^3.1.0",
 		"to-semver": "^1.1.0",
 		"webext-dynamic-content-scripts": "^2.0.1",
-		"webext-options-sync": "^0.11.0"
+		"webext-options-sync": "^0.11.0",
+		"webextension-polyfill": "^0.1.1"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/src/libs/mark-unread.js
+++ b/src/libs/mark-unread.js
@@ -1,16 +1,12 @@
+import browser from 'webextension-polyfill';
 import gitHubInjection from 'github-injection';
 import select from 'select-dom';
 import {h} from 'dom-chef';
+import SynchronousStorage from './synchronous-storage';
 import * as icons from './icons';
 import * as pageDetect from './page-detect';
 
-function loadNotifications() {
-	return JSON.parse(localStorage.getItem('unreadNotifications') || '[]');
-}
-
-function storeNotifications(unreadNotifications) {
-	localStorage.setItem('unreadNotifications', JSON.stringify(unreadNotifications || '[]'));
-}
+let storage;
 
 function stripHash(url) {
 	return url.replace(/#.+$/, '');
@@ -28,7 +24,7 @@ function addMarkUnreadButton() {
 }
 
 function markRead(url) {
-	const unreadNotifications = loadNotifications();
+	const unreadNotifications = storage.get();
 	unreadNotifications.forEach((notification, index) => {
 		if (notification.url === url) {
 			unreadNotifications.splice(index, 1);
@@ -41,7 +37,7 @@ function markRead(url) {
 		li.classList.add('read');
 	}
 
-	storeNotifications(unreadNotifications);
+	storage.set(unreadNotifications);
 }
 
 function markUnread() {
@@ -71,7 +67,7 @@ function markUnread() {
 	const dateTitle = lastCommentTime.title;
 	const date = lastCommentTime.getAttribute('datetime');
 
-	const unreadNotifications = loadNotifications();
+	const unreadNotifications = storage.get();
 
 	unreadNotifications.push({
 		participants,
@@ -84,7 +80,7 @@ function markUnread() {
 		url
 	});
 
-	storeNotifications(unreadNotifications);
+	storage.set(unreadNotifications);
 	updateUnreadIndicator();
 
 	this.setAttribute('disabled', 'disabled');
@@ -92,7 +88,7 @@ function markUnread() {
 }
 
 function renderNotifications() {
-	const unreadNotifications = loadNotifications()
+	const unreadNotifications = storage.get()
 		.filter(notification => !isNotificationExist(notification.url))
 		.filter(notification => {
 			if (!isParticipatingPage()) {
@@ -256,7 +252,7 @@ function updateUnreadIndicator() {
 	const statusMark = icon.querySelector('.mail-status');
 	const hasRealNotifications = icon.matches('[data-ga-click$=":unread"]');
 
-	const hasUnread = hasRealNotifications || loadNotifications().length > 0;
+	const hasUnread = hasRealNotifications || storage.get().length > 0;
 	const label = hasUnread ? 'You have unread notifications' : 'You have no unread notifications';
 
 	icon.setAttribute('aria-label', label);
@@ -281,7 +277,7 @@ function markAllNotificationsRead(e) {
 
 function addCustomAllReadBtn() {
 	const hasMarkAllReadBtnExists = select.exists('#notification-center a[href="#mark_as_read_confirm_box"]');
-	if (hasMarkAllReadBtnExists || loadNotifications().length === 0) {
+	if (hasMarkAllReadBtnExists || storage.get().length === 0) {
 		return;
 	}
 
@@ -302,7 +298,7 @@ function addCustomAllReadBtn() {
 	);
 
 	$(document).on('click', '#clear-local-notification', () => {
-		storeNotifications([]);
+		storage.set([]);
 		location.reload();
 	});
 }
@@ -310,14 +306,39 @@ function addCustomAllReadBtn() {
 function updateLocalNotificationsCount() {
 	const unreadCount = select('#notification-center .filter-list a[href="/notifications"] .count');
 	const githubNotificationsCount = Number(unreadCount.textContent);
-	const localNotifications = loadNotifications();
+	const localNotifications = storage.get();
 
 	if (localNotifications) {
 		unreadCount.textContent = githubNotificationsCount + localNotifications.length;
 	}
 }
 
-function setup() {
+// Migrate old localStorage.unreadNotifications to new storage.
+// For extra safety, keep the old notifications under a different name.
+// Drop function in mid August and drop the new key as well.
+function migrateOldStorage() {
+	const oldStorage = localStorage.getItem('unreadNotifications');
+	if (oldStorage) {
+		const list = JSON.parse(oldStorage);
+		console.log('Migrating old unreadNotifications storage', list);
+		storage.set(list);
+		localStorage.setItem('_unreadNotifications_migrated', JSON.stringify(list));
+		localStorage.removeItem('unreadNotifications');
+	}
+}
+
+async function setup() {
+	storage = await new SynchronousStorage(
+		() => {
+			return browser.storage.local.get({
+				unreadNotifications: []
+			}).then(storage => storage.unreadNotifications);
+		},
+		unreadNotifications => {
+			return browser.storage.local.set({unreadNotifications});
+		}
+	);
+	migrateOldStorage();
 	gitHubInjection(window, () => {
 		destroy();
 
@@ -329,7 +350,7 @@ function setup() {
 			$(document).on('click', '.js-mark-all-read', markAllNotificationsRead);
 			$(document).on('click', '.js-delete-notification button', updateUnreadIndicator);
 			$(document).on('click', 'form[action="/notifications/mark"] button', () => {
-				storeNotifications([]);
+				storage.set([]);
 			});
 		} else if (pageDetect.isPR() || pageDetect.isIssue()) {
 			markRead(location.href);

--- a/src/libs/synchronous-storage.js
+++ b/src/libs/synchronous-storage.js
@@ -1,0 +1,43 @@
+/**
+ * Allows usage of async get/set API synchronously.
+ * Requirements:
+ * - SynchronousStorage must be the only way to get/set the storage
+ * - The source API must be promised
+ * - The first call must be awaited to make sure the value has been loaded
+ *
+ * Usage:
+
+import SynchronousStorage from './synchronous-storage';
+
+const storage = await new SynchronousStorage(
+	() => browser.storage.local.get('name'),
+	va => browser.storage.local.set({name: va})
+);
+
+console.log(storage.get()); // {}
+storage.set('Federico');
+console.log(storage.get()); // {name: 'Federico'}
+
+ *
+ * Caveats:
+ * - .set() returns a promise that you can use to catch write errors.
+ *   However if an error happens, SynchronousStorage will no longer match the real cache.
+ */
+export default class SynchronousStorage {
+	constructor(get, set) {
+		this._get = get;
+		this._set = set;
+		return get().then(value => {
+			this._cache = value;
+			return this;
+		});
+	}
+	get() {
+		return this._cache;
+	}
+	set(value) {
+		this._cache = value;
+		return this._set(value);
+	}
+}
+


### PR DESCRIPTION
* Move mark-unread to browser.storage.local

* Add migration to preserve existing unreads

This is run in the first RGH load after an update.
The notifications are still preserved in localStorage just in case I
failed as a developer.